### PR TITLE
Don't call player.updateInventory() on menu update

### DIFF
--- a/src/main/java/me/hsgamer/bettergui/object/menu/SimpleMenu.java
+++ b/src/main/java/me/hsgamer/bettergui/object/menu/SimpleMenu.java
@@ -311,7 +311,6 @@ public class SimpleMenu extends Menu<SimpleInventory> {
 
     public void updateInventory() {
       createItems(true);
-      player.updateInventory();
     }
 
     @Override


### PR DESCRIPTION
Fixes the repeating equip animation of the held item