### PR TITLE
Allow bypassing open check

### DIFF
--- a/src/main/java/me/hsgamer/bettergui/action/type/OpenMenuAction.java
+++ b/src/main/java/me/hsgamer/bettergui/action/type/OpenMenuAction.java
@@ -15,8 +15,10 @@ import java.util.UUID;
 import static me.hsgamer.bettergui.BetterGUI.getInstance;
 
 public class OpenMenuAction extends BaseAction {
+  private final boolean bypass;
   public OpenMenuAction(ActionBuilder.Input input) {
     super(input);
+    this.bypass = !input.option.isEmpty() && Boolean.parseBoolean(input.option);
   }
 
   @Override
@@ -41,9 +43,9 @@ public class OpenMenuAction extends BaseAction {
       Runnable runnable;
       Menu parentMenu = getMenu();
       if (parentMenu != null) {
-        runnable = () -> getInstance().getMenuManager().openMenu(menu, player, finalArgs, parentMenu, false);
+        runnable = () -> getInstance().getMenuManager().openMenu(menu, player, finalArgs, parentMenu, bypass);
       } else {
-        runnable = () -> getInstance().getMenuManager().openMenu(menu, player, finalArgs, false);
+        runnable = () -> getInstance().getMenuManager().openMenu(menu, player, finalArgs, bypass);
       }
       Scheduler.current().sync().runEntityTaskWithFinalizer(player, runnable, process::next);
     } else {

--- a/src/main/java/me/hsgamer/bettergui/action/type/OpenMenuAction.java
+++ b/src/main/java/me/hsgamer/bettergui/action/type/OpenMenuAction.java
@@ -18,7 +18,7 @@ public class OpenMenuAction extends BaseAction {
   private final boolean bypass;
   public OpenMenuAction(ActionBuilder.Input input) {
     super(input);
-    this.bypass = !input.option.isEmpty() && Boolean.parseBoolean(input.option);
+    this.bypass = input.option.equalsIgnoreCase("bypassChecks");
   }
 
   @Override


### PR DESCRIPTION
after https://github.com/BetterGUI-MC/BetterGUI/commit/69b8033e2a7e1478e1d3a2c5459f43f58a049370 we can't easily bypass open requirements without blocking the access from /open command

This bypass adds a parameter to open action which restores the old behaviour (but now even without the permission)